### PR TITLE
Catch java.lang.IllegalArgumentExceptions to add more to the message

### DIFF
--- a/src/funcade/jwks.clj
+++ b/src/funcade/jwks.clj
@@ -2,17 +2,16 @@
   (:require [jsonista.core :as json]
             [buddy.core.keys :as bk]
             [org.httpkit.client :as http]
-            [jsonista.core :as j]
             [funcade.tools :as t]))
 
 (defn- group-by-kid [certs]
- (->> (for [{:keys [kid] :as cert} certs]
-        [kid (bk/jwk->public-key cert)])
-      (into {})))
+  (->> (for [{:keys [kid] :as cert} certs]
+         [kid (bk/jwk->public-key cert)])
+       (into {})))
 
 (defn- parse-jwk-response [{:keys [body] :as response}]
   (try
-    (-> (j/read-value body t/mapper)
+    (-> (json/read-value body t/mapper)
         :keys
         group-by-kid)
     (catch Exception ex


### PR DESCRIPTION
We are getting an error thrown that does not contain enough information for use to find the root cause.  Add a catch block for that exception type, and rethrow with more added to the message.

via
[{:type java.lang.IllegalArgumentException, :message "No implementation of method: :resolve-key of protocol: #'buddy.sign.util/IKeyProvider found for class: nil", :at "clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:584)"}]

trace
["clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:584)" 
 "clojure.core$_cache_protocol_fn.invoke(core_deftype.clj:576)" 
 "buddy.sign.util$fn__8320$G__8315__8327.invoke(util.clj:20)" 
 "buddy.sign.jws$unsign$fn__8542.invoke(jws.clj:162)" 
 "buddy.sign.jws$unsign.invokeStatic(jws.clj:161)" 
 "buddy.sign.jws$unsign.invoke(jws.clj:153)" 
 "buddy.sign.jwt$unsign.invokeStatic(jwt.clj:129)" 
 "buddy.sign.jwt$unsign.invoke(jwt.clj:125)" 
 "funcade.middleware.buddy$jwks_backend$reify__9112._authenticate(buddy.clj:43)" 
 "buddy.auth.middleware$authenticate_request.invokeStatic(middleware.clj:39)" 
 "buddy.auth.middleware$authenticate_request.invoke(middleware.clj:25)" 
 "buddy.auth.middleware$authentication_request.invokeStatic(middleware.clj:49)" 
 "buddy.auth.middleware$authentication_request.doInvoke(middleware.clj:42)" 
 "clojure.lang.RestFn.applyTo(RestFn.java:139)" 
 "clojure.core$apply.invokeStatic(core.clj:669)" 
 "clojure.core$apply.invoke(core.clj:662)" 
 "buddy.auth.middleware$wrap_authentication$fn__10398.invoke(middleware.clj:60)" ]