### PR TITLE
With `funcade` using `:jwks/keyset` to authenticate store it as state

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                  [com.auth0/java-jwt "3.19.2"]
                  [org.clojure/tools.logging "1.2.4"]
                  [funcool/cuerdas "2021.05.29-0"]
+                 [tolitius/calip "0.1.13"]
                  [metosin/jsonista "0.3.5"]
                  [com.rpl/specter "1.1.4"]
                  [camel-snake-kebab "0.4.2"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tolitius/funcade "0.1.18"
+(defproject tolitius/funcade "0.1.18-SNAPSHOT"
   :description "creates, manages and refreshes oauth 2.0 jwt tokens"
   :url "https://github.com/tolitius/funcade"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
                  [com.auth0/java-jwt "3.19.2"]
                  [org.clojure/tools.logging "1.2.4"]
                  [funcool/cuerdas "2021.05.29-0"]
-                 [tolitius/calip "0.1.13"]
                  [metosin/jsonista "0.3.5"]
                  [com.rpl/specter "1.1.4"]
                  [camel-snake-kebab "0.4.2"]])

--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -73,7 +73,7 @@
           [source (wake-token-master source config)])))
 
 
-(defn get-valid-kids
+(defn find-current-kids
   "I return the valid kid stored from the keyset provided by
   Authentication provider"
   []

--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -73,7 +73,7 @@
           [source (wake-token-master source config)])))
 
 
-(defn find-current-kids
+(defn get-valid-kids
   "I return the valid kid stored from the keyset provided by
   Authentication provider"
   []

--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -2,7 +2,8 @@
   (:require [clojure.core.async :as a]
             [clojure.tools.logging :as log]
             [funcade.tools :as tools]
-            [funcade.tokens :as t]))
+            [funcade.tokens :as t]
+            [funcade.jwks]))
 
 (defn- stop-token-channel! [stop-chan]
   (a/put! stop-chan ::stop))
@@ -70,3 +71,10 @@
   (into {}
         (for [[source config] configs]
           [source (wake-token-master source config)])))
+
+
+(defn get-valid-kids
+  "I return the valid kid stored from the keyset provided by
+  Authentication provider"
+  []
+  (keys @#'funcade.jwks/keyset))

--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -73,8 +73,8 @@
           [source (wake-token-master source config)])))
 
 
-(defn get-valid-kids
-  "I return the valid kid stored from the keyset provided by
+(defn find-current-kids
+  "I return the current kids stored from the keyset provided by
   Authentication provider"
   []
   (keys @#'funcade.jwks/keyset))

--- a/src/funcade/jwks.clj
+++ b/src/funcade/jwks.clj
@@ -5,10 +5,14 @@
             [jsonista.core :as j]
             [funcade.tools :as t]))
 
+(defonce ^:private
+  keyset (atom {}))
+
 (defn- group-by-kid [certs]
  (->> (for [{:keys [kid] :as cert} certs]
         [kid (bk/jwk->public-key cert)])
-      (into {})))
+      (into {})
+      (reset! keyset)))
 
 (defn- parse-jwk-response [{:keys [body] :as response}]
   (try

--- a/src/funcade/middleware/buddy.clj
+++ b/src/funcade/middleware/buddy.clj
@@ -3,8 +3,7 @@
             [buddy.auth :as auth]
             [buddy.auth.protocols :as proto]
             [buddy.sign.jwt :as jwt]
-            [buddy.auth.backends]
-            [calip.core :as calip]))
+            [buddy.auth.backends]))
 
 (defn validate-scope [handler request required-scopes]
   (let [decoded-token (request :identity)]
@@ -20,24 +19,7 @@
                   :required required-scopes
                   :scopes   scopes}}))))
 
-(defn- -authenticate-request
-  "I authenticate the request"
-  [request token {:keys [keyset options authfn on-error]}]
-  (try
-    (let [tkey (jk/find-token-key keyset token)]
-      (when-not tkey
-        (throw (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
-                        {:type :validation :cause :incorrect-sign-key})))
-      (authfn (jwt/unsign token tkey options)))
-    (catch clojure.lang.ExceptionInfo e
-      (let [data (ex-data e)]
-        (when (fn? on-error)
-          (on-error {:request         request
-                     :exception/data  data}
-                    e))
-        nil))))
-
-(defn authenticate-scope [handler scope]
+(defn authenticate [handler scope]
   (fn [request]
     (if (auth/authenticated? request)
       (validate-scope handler request scope)
@@ -50,18 +32,25 @@
     :or   {authfn identity token-name "Bearer" options {:alg :rs256}
            on-error #(println "[funcade] error: " %&)}}]
   {:pre [(ifn? authfn)]}
-  (calip/measure #{#'funcade.middleware.buddy/-authenticate-request}
-                 {:on-error? true})
   (reify
     proto/IAuthentication
     (-parse [_ request]
       (#'buddy.auth.backends.token/parse-header request token-name))
 
     (-authenticate [_ request data]
-      (-authenticate-request request data {:keyset    keyset
-                                           :options   options
-                                           :on-error  on-error
-                                           :authfn    authfn}))
+      (try
+        (let [tkey (jk/find-token-key keyset data)]
+          (when-not tkey
+            (throw (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
+                            {:type :validation :cause :incorrect-sign-key})))
+          (authfn (jwt/unsign data tkey options)))
+        (catch clojure.lang.ExceptionInfo e
+          (let [data (ex-data e)]
+            (when (fn? on-error)
+              (on-error {:request         request
+                         :exception/data  data}
+                        e))
+            nil))))
 
     proto/IAuthorization
     (-handle-unauthorized [_ request metadata]

--- a/src/funcade/middleware/reitit.clj
+++ b/src/funcade/middleware/reitit.clj
@@ -24,4 +24,4 @@
   | `:scope`     | `:edit` required scope as keyword, does not mount if not set"
   {:name    ::scope
    :compile (fn [{:keys [scope]} _]
-              (if scope #(fmb/authenticate-scope % scope)))})
+              (if scope #(fmb/authenticate % scope)))})

--- a/src/funcade/middleware/reitit.clj
+++ b/src/funcade/middleware/reitit.clj
@@ -24,4 +24,4 @@
   | `:scope`     | `:edit` required scope as keyword, does not mount if not set"
   {:name    ::scope
    :compile (fn [{:keys [scope]} _]
-              (if scope #(fmb/authenticate % scope)))})
+              (if scope #(fmb/authenticate-scope % scope)))})


### PR DESCRIPTION
 ## gist
Currently `funcade` while invoking `#'funcade.jwks/jwks->keys` function which actually builds the `keyset` from the `auth/provider`, adding support to store the `keyset` in state for future reference or debugging unknown auth failures.  Also add support for `on-error` function to `println` by default to understand the `error` occured during authenticating the request

 ## fixes done
* Added `keyset` which is an `atom` that stores the `jwks->keyset` value and its **private** exposed a function within `#'funcade.core/get-valid-kids` which returns the `keys` from the `keyset` that are the `kid` values
* Added `default` value for `on-error` to `println` the actual error

 ## changelog
* Modified **funcade.core**
  * Added **get-valid-kids** function which returns the state of `keyset`
*  Modified **funcade.jwks**
  * Added **keyset** which is `private` and an `atom`
* Modified **funcade.middleware.buddy**
  * Added logic to support `on-error` with `default` function
* Modified **project.clj** bumped as SNAPSHOT version