### PR TITLE
fix runtime `TypecastException`

### DIFF
--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -72,9 +72,11 @@
         (for [[source config] configs]
           [source (wake-token-master source config)])))
 
-
 (defn find-current-kids
   "I return the current kids stored from the keyset provided by
   Authentication provider"
   []
-  (keys @#'funcade.jwks/keyset))
+  (-> #'funcade.jwks/keyset
+      var-get
+      deref
+      keys))


### PR DESCRIPTION
 ## preface
With recent fix of supporting `:jwks/keyset` debugging, the function `#'funcade.core/fimd-current-kids` will fail while executing at runtime with `type-cast` exception. The reason for such exception is because since `#'funcade.jwks/keyset` is a variable we need to `get-value` of the `variable` and then proceed with logic to be applied on value

 ## fixes done
* Modified **funcade.core/find-current-kids** to make use of `var-get` instead of directly accessing the value

 ## changelog
* Modified **funcade.core/find-current-kids** fixing run time `typecast` exception

 ## reference
```clojure
dev=> (-> #'funcade.jwks/keyset var-get deref keys)
(:kid-1 :kid-2)
```