### PR TITLE
support `funcade` to refresh tokens on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ invalid scope:
 ;; {:status 401, :body {:message "missing required scope", :required :my-scope, :scopes (:not-my-scope)}}
 ```
 
-### Support middleware `keyset` refresh
+### `keyset` refresh
 
 `funcade` as of version `0.1.25` supports `keyset-refresh` functionality, which refreshes the `keyset` used
 for `token-validation` given a specific `interval-ms` _iff provided_

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,16 @@
 {:paths ["src" "classes"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        com.auth0/java-jwt {:mvn/version "4.4.0"}
-        org.clojure/tools.logging {:mvn/version "1.2.4"}
+ :deps {org.clojure/clojure                 {:mvn/version "1.11.1"}
+        com.auth0/java-jwt                  {:mvn/version "4.4.0"}
+        org.clojure/tools.logging           {:mvn/version "1.2.4"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.2"}
-        http-kit/http-kit {:mvn/version "2.6.0"}
-        funcool/cuerdas {:mvn/version "2021.05.29-0"}
-        buddy/buddy-auth {:mvn/version "3.0.323"}
-        com.rpl/specter {:mvn/version "1.1.4"}
-        buddy/buddy-sign {:mvn/version "3.5.351"}
-        metosin/jsonista {:mvn/version "0.3.8"}
-        org.clojure/core.async {:mvn/version "1.6.681"}}
+        http-kit/http-kit                   {:mvn/version "2.6.0"}
+        funcool/cuerdas                     {:mvn/version "2021.05.29-0"}
+        buddy/buddy-auth                    {:mvn/version "3.0.323"}
+        com.rpl/specter                     {:mvn/version "1.1.4"}
+        buddy/buddy-sign                    {:mvn/version "3.5.351"}
+        metosin/jsonista                    {:mvn/version "0.3.8"}
+        org.clojure/core.async              {:mvn/version "1.6.681"}
+        tolitius/yang                       {:mvn/version "0.1.41"}}
  :aliases {:dev {:extra-deps {}}
            :repl {;; :extra-paths ["test" "test/resources"]
                   :extra-deps {nrepl/nrepl {:mvn/version "0.7.0"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tolitius/funcade "0.1.24-SNAPSHOT"
+(defproject tolitius/funcade "0.1.25"
   :description "creates, manages and refreshes oauth 2.0 jwt tokens"
   :url "https://github.com/tolitius/funcade"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tolitius/funcade "0.1.25"
+(defproject tolitius/funcade "0.1.24-SNAPSHOT"
   :description "creates, manages and refreshes oauth 2.0 jwt tokens"
   :url "https://github.com/tolitius/funcade"
   :license {:name "Eclipse Public License"
@@ -16,4 +16,5 @@
                  [funcool/cuerdas "2021.05.29-0"]
                  [metosin/jsonista "0.3.5"]
                  [com.rpl/specter "1.1.4"]
-                 [camel-snake-kebab "0.4.2"]])
+                 [camel-snake-kebab "0.4.2"]
+                 [tolitius/yang "0.1.41"]])

--- a/src/funcade/core.clj
+++ b/src/funcade/core.clj
@@ -71,12 +71,3 @@
   (into {}
         (for [[source config] configs]
           [source (wake-token-master source config)])))
-
-(defn find-current-kids
-  "I return the current kids stored from the keyset provided by
-  Authentication provider"
-  []
-  (-> #'funcade.jwks/keyset
-      var-get
-      deref
-      keys))

--- a/src/funcade/jwks.clj
+++ b/src/funcade/jwks.clj
@@ -5,14 +5,10 @@
             [jsonista.core :as j]
             [funcade.tools :as t]))
 
-(defonce ^:private
-  keyset (atom {}))
-
 (defn- group-by-kid [certs]
  (->> (for [{:keys [kid] :as cert} certs]
         [kid (bk/jwk->public-key cert)])
-      (into {})
-      (reset! keyset)))
+      (into {})))
 
 (defn- parse-jwk-response [{:keys [body] :as response}]
   (try
@@ -32,9 +28,43 @@
           (ex-info response)
           throw))))
 
-(defn find-token-key [jwks token]
+(declare refresh-kids
+         find-keyset
+         current-kids)
+
+(defn jwks->keys-fn
+  "Generate the keyset and return getter-fn"
+  [url]
+  (let [keyset    (jwks->keys url)]
+    (alter-var-root (var refresh-kids) (fn [existing-mapping]
+                                         (with-meta
+                                           ;; make sure don't alter the root more than once if already
+                                           ;; set
+                                           (if (-> existing-mapping meta :plugged? true?)
+                                             existing-mapping
+                                             (fn []
+                                               (jwks->keys-fn url)
+                                               (prn "[funcade]: done refreshing keyset")))
+                                           {:plugged? true})))
+    (alter-var-root (var current-kids) (fn [_]
+                                         (with-meta
+                                           (some-> keyset keys)
+                                           (meta (var current-kids)))))
+    (alter-var-root (var find-keyset) (fn [_]
+                                        (with-meta
+                                          (fn [& kids]
+                                            (when (seq kids)
+                                              (get-in keyset kids))) 
+                                          (meta (var find-keyset)))))
+    find-keyset))
+
+(defn find-kid [token]
   (some-> token
           t/decode64
           (json/read-value t/mapper)
-          :kid
+          :kid))
+
+(defn find-token-key [jwks token]
+  (some-> token
+          find-kid  
           jwks))

--- a/src/funcade/middleware/buddy.clj
+++ b/src/funcade/middleware/buddy.clj
@@ -1,5 +1,5 @@
 (ns funcade.middleware.buddy
-  (:require [funcade.jwks :as jk]
+  (:require [funcade.jwks :as jwks]
             [buddy.auth :as auth]
             [buddy.auth.protocols :as proto]
             [buddy.sign.jwt :as jwt]
@@ -28,7 +28,7 @@
                 :message (str "access to " (request :uri) " is not authorized")}})))
 
 (defn jwks-backend
-  [{:keys [keyset authfn unauthorized-handler options token-name on-error]
+  [{:keys [keyset authfn unauthorized-handler options token-name on-error keyset-fn]
     :or   {authfn identity token-name "Bearer" options {:alg :rs256}
            on-error #(println "[funcade] error: " %&)}}]
   {:pre [(ifn? authfn)]}
@@ -39,7 +39,10 @@
 
     (-authenticate [_ request data]
       (try
-        (let [tkey (jk/find-token-key keyset data)]
+        (let [tkey (if (and (some? keyset-fn)
+                            (fn? keyset-fn))
+                     (keyset-fn (jwks/find-kid data))
+                     (jwks/find-token-key keyset data))]
           (when-not tkey
             (throw (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
                             {:type :validation :cause :incorrect-sign-key})))
@@ -61,5 +64,7 @@
 (defn jwks-authenticator
   "JSON Web Key Set specific:
    i.e. needs a 'https://foo.com/bar/jwks' URI that returns unsign keys"
-  [{:keys [uri] :as options}]
-  (jwks-backend (assoc options :keyset (jk/jwks->keys uri))))
+  [{:keys [uri refresh-keyset?] :as options}]
+  (jwks-backend (cond-> options
+                       (not refresh-keyset?)  (assoc :keyset (jwks/jwks->keys uri))
+                       refresh-keyset?        (assoc :keyset-fn (jwks/jwks->keys-fn uri)))))


### PR DESCRIPTION
 ## preface
With `funcade` middleware to fetch `jwks-keyset` while starting `reitit-middleware` + `buddy-middleware` for certain `authenticator` it may require to refresh the token periodically to obtain new `kid` for `jwks` authentication. In order to make sure authentication still happens we need to refresh those `keyset` and for which we are exposing functions which actually refreshes the `keyset` and updates the refrence for the `variable`

 ## fixes done
* Added `jwks->keys-fn` which returns the `fn` which returns the `cert` given the `kid`
* Added `refresh-keyset` which actually refreshes the `keyset` and updates the `variable-reference`
* Made the `current-kids` _dynamic_
* Updated `buddy-middleware` which supports `refresh-keyset?` option which actually enables `refresh` support via `clojure-fn`
* Added `find-kid` function which extracts `kid` from `token`
* Modified `find-token-key` to make use of `find-kid` function
* Changes are working fine validated locally

 ## unit testing
```clojure
dev=> funcade.jwks/current-kids
("kid1", "kid2", "kid3")
dev=> (funcade.jwks/refresh-kids)
"[funcade]: done refreshing keyset"
nil
dev=> funcade.jwks/current-kids
("kid1.1", "kid2.2", "kid3.3")
```