### PR TITLE
Supporting `jwks-keyset` refresh _only once_ for concrete UNAUTHORIZED

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.clojure/core.async "0.4.474"]
                  [buddy/buddy-sign "3.4.333"]
                  [buddy/buddy-auth "3.0.323"]
-                 [http-kit "2.5.3"]
+                 [http-kit "2.6.0"]
                  [com.auth0/java-jwt "3.19.2"]
                  [org.clojure/tools.logging "1.2.4"]
                  [funcool/cuerdas "2021.05.29-0"]

--- a/src/funcade/jwks.clj
+++ b/src/funcade/jwks.clj
@@ -53,13 +53,15 @@
 
 (defn refresh-kids
   "refresh jwks keyset from auth provider"
-  [uri callback]
-  (let [current-kids      (-> uri jwks->keys keys) 
-        refresh-callback  (or callback
-                             (fn [_]
-                               (prn "[funcade]: refreshed keyset")))] 
-    (refresh-callback current-kids)
-    current-kids))
+  ([uri]
+   (refresh-kids uri nil))
+  ([uri callback]
+   (let [current-kids      (-> uri jwks->keys keys) 
+         refresh-callback  (or callback
+                               (fn [_]
+                                 (prn "[funcade]: refreshed keyset")))] 
+     (refresh-callback current-kids)
+     current-kids)))
 
 (defn jwks->keyset
   "Generate the keyset and return getter-fn

--- a/src/funcade/middleware/buddy.clj
+++ b/src/funcade/middleware/buddy.clj
@@ -28,9 +28,10 @@
                 :message (str "access to " (request :uri) " is not authorized")}})))
 
 (defn jwks-backend
-  [{:keys [authfn unauthorized-handler options token-name on-error]
+  [{:keys [authfn unauthorized-handler options token-name on-error retry-keyset-refresh? uri]
     :or   {authfn identity token-name "Bearer" options {:alg :rs256}
-           on-error #(println "[funcade] error: " %&)}}]
+           on-error #(println "[funcade] error: " %&)
+           retry-keyset-refresh? true}}]
   {:pre [(ifn? authfn)]}
   (reify
     proto/IAuthentication
@@ -39,13 +40,22 @@
 
     (-authenticate [_ request data]
       (try
-        (let [tkey (-> data
-                       jwks/find-kid
-                       jwks/find-token-key-by-kid)]
-          (when-not tkey
-            (throw (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
-                            {:type :validation :cause :incorrect-sign-key})))
-          (authfn (jwt/unsign data tkey options)))
+        (letfn [(validate-token ([token-data]
+                                 (-> token-data
+                                     jwks/find-kid
+                                     jwks/find-token-key-by-kid)))
+                (authenticate-request ([token-key retry?]
+                                       (if token-key
+                                         (authfn (jwt/unsign data token-key options))
+                                         (let [unauthorized-error (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
+                                                                           {:type :validation :cause :incorrect-sign-key})]
+                                           (if retry? 
+                                             (do (jwks/refresh-kids uri nil) ;; nil is to avoid refresh scheduler
+                                                 (-> (validate-token data)
+                                                     (authenticate-request false))) 
+                                             (throw unauthorized-error))))))]
+          (-> (validate-token data)
+              (authenticate-request retry-keyset-refresh?)))
         (catch clojure.lang.ExceptionInfo e
           (let [data (ex-data e)]
             (when (fn? on-error)

--- a/src/funcade/middleware/buddy.clj
+++ b/src/funcade/middleware/buddy.clj
@@ -27,11 +27,36 @@
        :body   {:error   "invalid authorization header"
                 :message (str "access to " (request :uri) " is not authorized")}})))
 
+(defn- authenticate-request
+  [token-data
+   {:keys [refresh-keyset?
+           options
+           uri]
+    :as auth-opts}]
+  (if-let [request-token-kid (-> token-data
+                                 jwks/find-kid
+                                 jwks/find-token-key-by-kid)]
+    (jwt/unsign token-data request-token-kid (or options
+                                                 {:alg :rs256})) 
+    (if refresh-keyset?
+      (do (jwks/refresh-kids uri)
+          (->> (assoc auth-opts :refresh-keyset? false)
+               (authenticate-request token-data))) 
+      (throw (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
+                      {:type :validation :cause :incorrect-sign-key})))))
+
 (defn jwks-backend
-  [{:keys [authfn unauthorized-handler options token-name on-error retry-keyset-refresh? uri]
-    :or   {authfn identity token-name "Bearer" options {:alg :rs256}
-           on-error #(println "[funcade] error: " %&)
-           retry-keyset-refresh? true}}]
+  [{jwt-header-options :options
+    jwt-keyset-uri     :uri
+    :keys [authfn
+           unauthorized-handler
+           token-name
+           on-error
+           refresh-keyset-on-error?]
+    :or   {authfn                   identity
+           token-name               "Bearer" 
+           on-error                 #(println "[funcade] error: " %&)
+           refresh-keyset-on-error? true}}]
   {:pre [(ifn? authfn)]}
   (reify
     proto/IAuthentication
@@ -40,22 +65,11 @@
 
     (-authenticate [_ request data]
       (try
-        (letfn [(validate-token ([token-data]
-                                 (-> token-data
-                                     jwks/find-kid
-                                     jwks/find-token-key-by-kid)))
-                (authenticate-request ([token-key retry?]
-                                       (if token-key
-                                         (authfn (jwt/unsign data token-key options))
-                                         (let [unauthorized-error (ex-info "jwt token is signed by unknown key (i.e. no public key in JSON Web Key Sets to verify the signature)"
-                                                                           {:type :validation :cause :incorrect-sign-key})]
-                                           (if retry? 
-                                             (do (jwks/refresh-kids uri nil) ;; nil is to avoid refresh scheduler
-                                                 (-> (validate-token data)
-                                                     (authenticate-request false))) 
-                                             (throw unauthorized-error))))))]
-          (-> (validate-token data)
-              (authenticate-request retry-keyset-refresh?)))
+        (-> (authenticate-request data
+                                  {:refresh-keyset? refresh-keyset-on-error?
+                                   :options         jwt-header-options
+                                   :uri             jwt-keyset-uri})
+            authfn) 
         (catch clojure.lang.ExceptionInfo e
           (let [data (ex-data e)]
             (when (fn? on-error)


### PR DESCRIPTION
 ## preface
`funcade` recently had included the support for _refreshing `jwks-keyset` given the interval_, but with which still there are chances that `funcade` can have `keyset` mismatch with `AUTH_SERVER` i.e., For instance, if `funcade` refreshes `jwks-keyset` at 9 Aug 2024 10:00 AM GMT and `AUTH_SERVER` refreshes their `keyset` at 9 Aug 2024 10:15 AM GMT, then `funcade` will throw `UNAUTHORIZED` error till _next refresh_. So to handle the same, while _authenticating_ the request `funcade` makes sure it _has updated `jwks-keyset` _iff_ **no `kid` is found**, and still if the `kid` isn't found then it throw `UNAUTHORIZED` error

 ## fixes done
* Bumping `http-kit` from `2.5.6` to `2.6.0`
* Updating logic inside `-authenticate` method to `refresh-kids` _only once iff_ `(= kid nil)` and if the same happens throws UNAUTHORIZED error