### PR TITLE
switch base64 decoding from string to url

### DIFF
--- a/src/funcade/codec.clj
+++ b/src/funcade/codec.clj
@@ -37,10 +37,10 @@
         {:funcade/error ex}))))
 
 (defn decode64 [^String s]
-  (.decode (Base64/getDecoder) s))
+  (.decode (Base64/getUrlDecoder) s))
 
 (defn encode64 [^bytes bs]
-  (.encodeToString (Base64/getEncoder) bs))
+  (.encodeToString (Base64/getUrlEncoder) bs))
 
 (def mapper (json/object-mapper {:decode-key-fn keyword}))
 


### PR DESCRIPTION
The [JWT RFC](https://datatracker.ietf.org/doc/html/rfc7519) states that each segment of the JSON Web Token should be Base64 URL encoded value: 

> _"A JWT is represented as a sequence of URL-safe parts separated by period ('.') characters.  Each part contains a base64url-encoded value."_

<img width="689" alt="image" src="https://github.com/user-attachments/assets/d0f179fd-ca8d-40e9-9de1-9d8326a956a0">

This PR updates `funcade` to use the Base64 URL decoder on the JWT payload rather than the default String decoder 