### PR TITLE
Handle continous invoking `#'funcade.jwks/jwks->keys` for every route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean aot jar tag outdated install deploy tree repl
+.PHONY: clean aot jar tag outdated install deploy tree repl test
 
 clean:
 	rm -rf target
@@ -28,3 +28,6 @@ tree:
 
 repl:
 	clojure -A:dev -A:repl
+
+test:
+	clojure -M:test

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,11 @@
            :jar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.128"}}
                  :extra-paths ["target/about"]
                  :main-opts ["-m" "hf.depstar.jar" "target/funcade.jar" "--exclude" "clojure/core/specs/alpha.*"]}
+           :test {:extra-deps   {robert/hooke                         {:mvn/version "1.3.0"}
+                                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                  :extra-paths  ["src" "test"]
+                  :main-opts    ["-m" "cognitect.test-runner"]
+                  :exec-fn      cognitect.test-runner.api/test}
            :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "target/funcade.jar"]}
            :install {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tolitius/funcade "0.1.24"
+(defproject tolitius/funcade "0.1.26"
   :description "creates, manages and refreshes oauth 2.0 jwt tokens"
   :url "https://github.com/tolitius/funcade"
   :license {:name "Eclipse Public License"

--- a/src/funcade/jwks.clj
+++ b/src/funcade/jwks.clj
@@ -14,7 +14,8 @@
 (defn stop-scheduled-refresh
   "stop the scheduled refresh"
   []
-  (some-> keyset-refresh-scheduler deref scheduler/stop))
+  (some-> keyset-refresh-scheduler deref scheduler/stop)
+  (reset! keyset-refresh-scheduler nil))
 
 (defn find-token-key-by-kid
   "Given the token's kid find the key from keyset"
@@ -73,7 +74,9 @@
         (when (nil? @keyset-refresh-scheduler)
           (->> (scheduler/every refresh-interval-ms
                                 (partial refresh-kids url refresh-callback))
-               (reset! keyset-refresh-scheduler))))
+               (reset! keyset-refresh-scheduler))
+          @keyset))
+      @keyset
       (jwks->keys url)))
 
 (defn find-kid [token]

--- a/test/funcade/core_test.clj
+++ b/test/funcade/core_test.clj
@@ -3,5 +3,5 @@
             [funcade.core :refer :all]))
 
 (deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+  (testing "I am FIXED"
+    (is (= 1 1))))

--- a/test/funcade/jwks_test.clj
+++ b/test/funcade/jwks_test.clj
@@ -1,0 +1,57 @@
+(ns funcade.jwks-test
+  (:require [funcade.jwks :as jwks]
+
+            [org.httpkit.client :as http]
+            [robert.hooke :as hook]
+
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :as log]))
+
+(defn- cleanup-states
+  []
+  (reset! (deref #'jwks/keyset) nil)
+  (jwks/stop-scheduled-refresh))
+
+(defonce random-dummy-keyset-json-string
+  "{\"keys\":[{\"kty\":\"RSA\",\"e\":\"AQAB\",\"use\":\"sig\",\"kid\":\"vtcn3t_xP47j-Cg2uUTLvk6qSfD-KOLlORWCZ1iWl_w\",\"alg\":\"RS512\",\"n\":\"ivOjDFcfFYWTYgz9rnRh6LcXsG5esXknyv0RiW8kK7sfbzgbuDblA4p6cxmKIyqdDWpnONk7g7ExASNPgrX23DTazEC-XTnDUdVNoQJQwwIErfwkfu2_ipWkCaRo54R5b7s-h7SYLEXkDSwZQFkFUM6u7Ul956xwdj1hKpnF3JZPRtN1jr9rOx-gLjaNgPo8xEJ2JR582rgVCRRol5czxPcvqVf1uDjkmshA9VKapbmXYb5pjQv9meZIwrEk_V9R6CcEXAPxzxIcJn5XUdWNCGVc5b7V92tEkSD4GdRjpC6w3hclzgzWC8sbCsmtBnv15tnAdi6vju95IUt5fgh0-Q\"}]}")
+
+(deftest ^:unit
+  jwks->keyset-should-not-call-API-for-every-route-use-from-state
+  (let [case1 "When \"refresh-interval-ms\" is not provided which means \"funcade\"'s authentication middleware for \"reitit\" will not refresh keyset periodically
+        in that case calling #'funcade.jwks/jwks->keyset for every route since its \"wrap-middleware\" should use value from state-variable
+        #'funcade.jwks/keyset"]
+    (log/info case1)
+    (testing case1
+      (let [api-call-counter (atom 0)
+            jwks-opts        {}
+            deref-sym        #(deref (deref %))
+            _                (hook/prepend jwks/jwks->keys
+                                           (swap! api-call-counter inc))]
+        (with-redefs [http/get (constantly (delay {:body random-dummy-keyset-json-string}))]
+          (let [_           (is (nil? (deref-sym #'jwks/keyset)))
+                auth-keyset (jwks/jwks->keyset "https://milky-way-galaxy/ext/jwtsigningcert/jwks" jwks-opts)]
+            (is (= auth-keyset (jwks/jwks->keyset "https://milky-way-galaxy/ext/jwtsigningcert/jwks" jwks-opts)))
+            (is (some? #'jwks/keyset))
+            (is (= 1 @api-call-counter))
+            (cleanup-states))))))
+  (let [case2 "When \"refresh-interval-ms\" is provided which means \"funcade\"'s authentication middleware for \"reitit\" will refresh keyset periodically
+        in that case calling #'funcade.jwks/jwks->keyset for every route since its \"wrap-middleware\" should use value from state-variable
+        #'funcade.jwks/keyset"]
+    (log/info case2)
+    (testing case2
+      (let [api-call-counter (atom 0)
+            deref-sym        #(deref (deref %))
+            jwks-opts        {:refresh-interval-ms 10000
+                              :refresh-callback    (fn [_] (println "[funcade]: token-refreshed"))}
+            _                (hook/prepend jwks/jwks->keys
+                                           (swap! api-call-counter inc))]
+        (with-redefs [http/get (constantly (delay {:body random-dummy-keyset-json-string}))]
+          (let [_           (is (nil? (deref-sym #'jwks/keyset)))
+                _           (is (nil? (deref-sym #'jwks/keyset-refresh-scheduler)))
+                auth-keyset (jwks/jwks->keyset "https://milky-way-galaxy/ext/jwtsigningcert/jwks" jwks-opts)]
+            (is (= auth-keyset (jwks/jwks->keyset "https://milky-way-galaxy/ext/jwtsigningcert/jwks" jwks-opts)
+                               (jwks/jwks->keyset "https://milky-way-galaxy/ext/jwtsigningcert/jwks" jwks-opts)))
+            (is (some? (deref-sym #'jwks/keyset)))
+            (is (some? (deref-sym #'jwks/keyset-refresh-scheduler)))
+            (is (= 2 @api-call-counter)) ;; this is because of Scheduler triggers the same refresh on another thread which causes twice call
+            (cleanup-states)))))))


### PR DESCRIPTION
 ## preface
With [recent change](https://github.com/tolitius/funcade/pull/9) which enabled `refreshing-keyset` on a schedule, even though it worked thanks @HariprasathSankaraiyan also @danielmiladinov for figuring out this issue :vulcan_salute:

 ## fixes done
* With `#'funcade.jwks/jwks->keyset` if `funcade.jwks/keyset` atom value is populate lets stop calling `jwks->keyset` over and over again, instead _iff_ `refresh-interval-ms` is provided then `scheduler` will be updating it periodically.
* point the latest version in `project.clj` for better tracking
* not bumping the version from `0.1.26` to `0.1.27` because this is a bug fix on existing functionality

 ## changelog
* Modified **project.clj** bumping the `version`
* Modified **funcade.jwks**
  * Modified **stop-scheduled-refresh** to set `#'funcade.jwks/keyset-refresh-scheduler` to `nil`
  * Modified **jwks->keyset** logic
    1. _if_ `refresh-interval-ms` is provided then a. set the `keyset-refresh-scheduler` _iff `nil?`_ and return `keyset` from state
    2. else check if `keyset` atom is `not-empty`
    3. else call `#'funcade.jwks/jwks->keys` which will call API fetch `keyset+kids` adn update `keyset` atom

 ## unit testing

> running `jwks` test-cases

```clojure
➜  funcade git:(handle_consistent_api_call_to_find_keysets_fix_OR_condition_wrapping) ✗ make test
clojure -M:test

Running tests in #{"test"}
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: yang.scheduler, being replaced by: #'yang.scheduler/parse-long

Testing funcade.core-test

Testing funcade.jwks-test
Nov 12, 2024 7:47:22 PM clojure.tools.logging$eval972$fn__975 invoke
INFO: When "refresh-interval-ms" is not provided which means "funcade"'s authentication middleware for "reitit" will not refresh keyset periodically
        in that case calling #'funcade.jwks/jwks->keyset for every route since its "wrap-middleware" should use value from state-variable
        #'funcade.jwks/keyset
Nov 12, 2024 7:47:22 PM clojure.tools.logging$eval972$fn__975 invoke
INFO: When "refresh-interval-ms" is provided which means "funcade"'s authentication middleware for "reitit" will refresh keyset periodically
        in that case calling #'funcade.jwks/jwks->keyset for every route since its "wrap-middleware" should use value from state-variable
        #'funcade.jwks/keyset
[funcade]: token-refreshed

Ran 2 tests containing 11 assertions.
0 failures, 0 errors.
```

> building `jar` and installing locally

```bash
➜  funcade git:(handle_consistent_api_call_to_find_keysets_fix_OR_condition_wrapping) ✗ make install
rm -rf target
rm -rf classes
mkdir classes
clj -e "(compile 'funcade.java-api)"
WARNING: Implicit use of clojure.main with options is deprecated, use -M
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: yang.scheduler, being replaced by: #'yang.scheduler/parse-long
funcade.java-api
clojure -A:tag
{:intel-exported-to target/about/META-INF/tolitius/funcade/about.edn}
clojure -A:jar
Building thin jar: target/funcade.jar
Processing pom.xml for {tolitius/funcade {:mvn/version "0.1.26"}}
clojure -A:install
Installing tolitius/funcade-0.1.26 to your local `.m2`
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
done.
```